### PR TITLE
Run go-survey-launcher in ECS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+rendered
+tmp
+.idea
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.pem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+  - tip
+install:
+  - go get github.com/dwradcliffe/hcl-lint
+script: go run $GOPATH/src/github.com/dwradcliffe/hcl-lint/lint.go .

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 ONS Digital
+Copyright (c) 2017 Crown Copyright (Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # eq-terraform-ecs
+
+Terraform project that creates the AWS ECS infrastructure for the EQ Survey-Runner
+
+To import this module add the following code into you Terraform project
+
+```
+module "survey-runner-ecs" {
+  source = "github.com/ONSdigital/eq-terraform-ecs"
+  env = "${var.env}"
+  aws_access_key = "${var.aws_access_key}"
+  aws_secret_key = "${var.aws_secret_key}"
+  dns_zone_id = "${var.dns_zone_id}"
+  dns_zone_name = "${var.dns_zone_name}"
+  certificate_arn = "${var.certificate_arn}"
+  vpc_id = "${module.survey-runner-vpc.vpc_id}"
+  public_subnet_ids = "${module.survey-runner-routing.public_subnet_ids}"
+  ecs_application_cidrs = "${var.ecs_application_cidrs}"
+  private_route_table_ids = "${module.survey-runner-routing.private_route_table_ids}"
+}
+```
+
+To run this module on its own run the following code. (Replacing 'XXX' with you values)
+
+```
+terraform apply -var "env=XXX" \
+                -var "aws_access_key=XXX" \
+                -var "aws_secret_key=XXX" \
+                -var "dns_zone_id=XXX" \
+                -var "dns_zone_name=XXX" \
+                -var "certificate_arn=XXX" \
+                -var "vpc_id=XXX" \
+                -var "public_subnet_ids=XXX" \
+                -var "ecs_application_cidrs=XXX" \
+                -var "private_route_table_ids=XXX"
+```

--- a/alb.tf
+++ b/alb.tf
@@ -1,0 +1,24 @@
+resource "aws_alb" "eq" {
+  name            = "${var.env}-eq-alb"
+  internal        = false
+  security_groups = ["${aws_security_group.eq_alb.id}"]
+  subnets         = ["${var.public_subnet_ids}"]
+
+  tags {
+    Name = "survey-runner-alb"
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_alb_listener" "eq" {
+  load_balancer_arn = "${aws_alb.eq.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "${var.certificate_arn}"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.survey_launcher.arn}"
+    type             = "forward"
+  }
+}

--- a/aws.tf
+++ b/aws.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "eu-west-1"
+}
+
+data "aws_caller_identity" "current" {}

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,0 +1,23 @@
+resource "aws_ecs_cluster" "eq" {
+  name = "${var.env}-eq"
+}
+
+resource "aws_launch_configuration" "ecs" {
+  name                   = "${var.env}-eq-ecs"
+  image_id               = "ami-175f1964" // Amazon ECS-Optimized AMI
+  instance_type          = "${var.ecs_instance_type}"
+  key_name               = "${var.ecs_aws_key_pair}"
+  iam_instance_profile   = "${aws_iam_instance_profile.eq_ecs.id}"
+  security_groups        = ["${aws_security_group.eq_ecs.id}"]
+  user_data              = "#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.eq.name} > /etc/ecs/ecs.config"
+}
+
+resource "aws_autoscaling_group" "eq_ecs" {
+  name                 = "${var.env}-eq-ecs"
+  availability_zones   = ["${var.availability_zones}"]
+  launch_configuration = "${aws_launch_configuration.ecs.name}"
+  vpc_zone_identifier = ["${aws_subnet.ecs_application.*.id}"]
+  min_size             = "${var.ecs_cluster_min_size}"
+  max_size             = "${var.ecs_cluster_max_size}"
+  desired_capacity     = "${var.ecs_cluster_desired_size}"
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -1,0 +1,81 @@
+variable "env" {
+  description = "The environment you wish to use"
+}
+
+variable "aws_secret_key" {
+  description = "Amazon Web Service Secret Key"
+}
+
+variable "aws_access_key" {
+  description = "Amazon Web Service Access Key"
+}
+
+variable "availability_zones" {
+  type        = "list"
+  description = "The availability zones"
+  default     = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}
+
+variable "ecs_instance_type" {
+  description = "ECS Instance Type"
+  default     = "t2.nano"
+}
+
+variable "ecs_aws_key_pair" {
+  description = "Amazon Web Service Key Pair for use by ecs - in production this value should be empty"
+  default     = ""
+}
+
+variable "ecs_cluster_min_size" {
+  description = "ECS Cluster Minimum number of instances"
+  default     = "1"
+}
+
+variable "ecs_cluster_max_size" {
+  description = "ECS Cluster Maximum number of instances"
+  default     = "3"
+}
+
+variable "ecs_cluster_desired_size" {
+  description = "ECS Cluster Desired number of instances"
+  default     = "1"
+}
+
+variable "vpc_id" {
+  description = "The survey runner VPC ID"
+}
+
+variable "public_subnet_ids" {
+  type = "list"
+  description = "The IDs of the public subnets for the external ELBs"
+}
+
+variable "vpc_peer_cidr_block" {
+  description = "The CIDR block of the peered VPC, optional"
+  default     = "0.0.0.0/0"
+}
+
+variable "ecs_application_cidrs" {
+  type        = "list"
+  description = "CIDR blocks for ecs application subnets"
+}
+
+variable "private_route_table_ids" {
+  type = "list"
+  description = "Route tables with route to NAT gateway"
+}
+
+# DNS
+variable "dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier"
+  default     = "Z2XIERRF1SJEYP"
+}
+
+variable "dns_zone_name" {
+  description = "Amazon Route53 DNS zone name"
+  default     = "eq.ons.digital."
+}
+
+variable "certificate_arn" {
+  description = "ARN of the IAM loaded TLS certificate for public ELB"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,61 @@
+resource "aws_iam_instance_profile" "eq_ecs" {
+  name  = "${var.env}_iam_instance_profile_for_eq_ecs"
+  role = "${aws_iam_role.eq_ecs.name}"
+}
+
+resource "aws_iam_role" "eq_ecs" {
+  name = "${var.env}_iam_instance_profile_for_eq_ecs"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["ecs.amazonaws.com", "ec2.amazonaws.com"]
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "eq_ecs" {
+  "statement" = {
+      "effect" = "Allow",
+      "actions" = [
+        "ecs:CreateCluster",
+        "ecs:DeregisterContainerInstance",
+        "ecs:RegisterContainerInstance",
+        "ecs:StartTelemetrySession",
+      ],
+      "resources" = [
+        "arn:aws:ecs:eu-west-1:${data.aws_caller_identity.current.account_id}:cluster/${aws_ecs_cluster.eq.name}"
+      ]
+    }
+
+  "statement" = {
+      "effect" = "Allow",
+      "actions" = [
+        "ecs:DiscoverPollEndpoint",
+        "ecs:Poll",
+        "ecs:SubmitContainerStateChange",
+        "ecs:SubmitTaskStateChange",,
+        "ecs:StartTelemetrySession"
+      ],
+      "resources" = [
+        "*"
+      ]
+    }
+
+
+}
+
+resource "aws_iam_role_policy" "eq_ecs" {
+  name = "${var.env}_iam_instance_profile_for_eq_ecs"
+  role = "${aws_iam_role.eq_ecs.id}"
+  policy = "${data.aws_iam_policy_document.eq_ecs.json}"
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "survey_runner_launcher_address" {
+  value = "https://${aws_route53_record.survey_launcher.fqdn}"
+}

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,0 +1,49 @@
+resource "aws_security_group" "eq_alb" {
+  name        = "${var.env}-eq-alb"
+  description = "Allow access from the internet or WAF"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port   = "443"
+    to_port     = "443"
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_peer_cidr_block}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.env}-eq-alb-access"
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_security_group" "eq_ecs" {
+  name        = "${var.env}-eq-ecs"
+  description = "Allow access from the internet or WAF"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port   = "0"
+    to_port     = "65535"
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_peer_cidr_block}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.env}-eq-ecs-access"
+    Environment = "${var.env}"
+  }
+}

--- a/subnets.tf
+++ b/subnets.tf
@@ -1,0 +1,20 @@
+# Private application subnets for apps
+resource "aws_subnet" "ecs_application" {
+  count             = "${length(var.ecs_application_cidrs)}"
+  vpc_id            = "${var.vpc_id}"
+  cidr_block        = "${var.ecs_application_cidrs[count.index]}"
+  availability_zone = "${var.availability_zones[count.index]}"
+
+  tags {
+    Name        = "${var.env}-ecs-application-subnet-${count.index+1}"
+    Environment = "${var.env}"
+    Type        = "Application"
+  }
+}
+
+# Associate subnets with route table to NAT gateway
+resource "aws_route_table_association" "private" {
+  count          = "${length(var.ecs_application_cidrs)}"
+  subnet_id      = "${element(aws_subnet.ecs_application.*.id, count.index)}"
+  route_table_id = "${var.private_route_table_ids[count.index]}"
+}

--- a/survey_launcher.tf
+++ b/survey_launcher.tf
@@ -1,0 +1,103 @@
+resource "aws_alb_target_group" "survey_launcher" {
+  depends_on = ["aws_alb.eq"]
+  name     = "${var.env}-survey-launcher-ecs"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+  health_check = {
+    interval = 5
+    timeout = 2
+  }
+
+  tags {
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_alb_listener_rule" "survey_launcher" {
+  listener_arn = "${aws_alb_listener.eq.arn}"
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.survey_launcher.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${aws_route53_record.survey_launcher.name}"]
+  }
+}
+
+resource "aws_route53_record" "survey_launcher" {
+  zone_id = "${var.dns_zone_id}"
+  name    = "${var.env}-surveys-launch.${var.dns_zone_name}"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${aws_alb.eq.dns_name}"]
+}
+
+data "template_file" "survey_launcher" {
+  template = "${file("${path.module}/task-definitions/survey-launcher.json")}"
+
+  vars {
+    SURVEY_RUNNER_URL = "https://${var.env}-surveys.${var.dns_zone_name}"
+  }
+}
+
+resource "aws_ecs_task_definition" "survey_launcher" {
+  family                = "${var.env}-survey-launcher"
+  container_definitions = "${data.template_file.survey_launcher.rendered}"
+}
+
+resource "aws_ecs_service" "survey_launcher" {
+  depends_on = ["aws_alb_target_group.survey_launcher"]
+  name            = "${var.env}-survey-launcher"
+  cluster         = "${aws_ecs_cluster.eq.id}"
+  task_definition = "${aws_ecs_task_definition.survey_launcher.arn}"
+  desired_count   = 3
+  iam_role        = "${aws_iam_role.survey_launcher.arn}"
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.survey_launcher.arn}"
+    container_name = "survey-launcher"
+    container_port = 8000
+  }
+}
+
+resource "aws_iam_role" "survey_launcher" {
+  name = "${var.env}_iam_for_survey_launcher"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["ecs.amazonaws.com", "ecs-tasks.amazonaws.com"]
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "survey_launcher" {
+  "statement" = {
+      "effect" = "Allow",
+      "actions" = [
+        "elasticloadbalancing:*",
+      ],
+      "resources" = [
+        "*"
+      ]
+    }
+}
+
+resource "aws_iam_role_policy" "survey_launcher" {
+  name = "${var.env}_iam_for_survey_launcher"
+  role = "${aws_iam_role.survey_launcher.id}"
+  policy = "${data.aws_iam_policy_document.survey_launcher.json}"
+}

--- a/task-definitions/survey-launcher.json
+++ b/task-definitions/survey-launcher.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "survey-launcher",
+    "image": "onsdigital/go-launch-a-survey",
+    "memoryReservation": 128,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8000,
+        "hostPort": 0
+      }
+    ],
+    "environment": [
+      {
+        "name": "SURVEY_RUNNER_URL",
+        "value": "${SURVEY_RUNNER_URL}"
+      }
+    ]
+  }
+]

--- a/task-definitions/survey_runner.json
+++ b/task-definitions/survey_runner.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "eq-survey-runner",
+    "image": "jonnyshaw89/eq-survey-runner:latest",
+    "memoryReservation": 256,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 5000,
+        "hostPort": 0
+      }
+    ],
+    "environment": [
+      {
+        "name": "EQ_DEV_MODE",
+        "value": "True"
+      },
+      {
+        "name": "EQ_SECRET_KEY",
+        "value": "${EQ_SECRET_KEY}"
+      },
+      {
+        "name": "EQ_SERVER_SIDE_STORAGE_DATABASE_URL",
+        "value": "${EQ_SERVER_SIDE_STORAGE_DATABASE_URL}"
+      },
+      {
+        "name": "EQ_RABBITMQ_URL",
+        "value": "${EQ_RABBITMQ_URL}"
+      },
+      {
+        "name": "EQ_RABBITMQ_URL_SECONDARY",
+        "value": "${EQ_RABBITMQ_URL_SECONDARY}"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "eu-west-1",
+        "awslogs-group": "${LOG_GROUP}"
+      }
+    }
+  }
+]

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,8 @@
+aws_access_key="XXXXXXXXXXXX"
+aws_secret_key = "XXXXXXXXXXXX"
+ecs_application_cidrs=["10.30.20.32/28", "10.30.20.48/28", "10.30.20.64/28"]
+
+dns_zone_id="XXXX"
+dns_zone_name="dev.eq.ons.digital"
+
+certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"


### PR DESCRIPTION
Created a basic ECS cluster to start running `onsdigital/go-launch-a-survey` which allows us to better simulate an upstream system sending a user to us.

### How to Review
Add the module definition (Defined in the README) to the `survey-runner.tf` file in your `eq-terraform` checkout. Run `terraform apply` in the `eq-terraform` folder to deploy this module alongside the rest of the survey-runner application.