### PR TITLE
Support loading of Secrets from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,9 @@ terraform apply -var "env=XXX" \
                 -var "vpc_id=XXX" \
                 -var "public_subnet_ids=XXX" \
                 -var "ecs_application_cidrs=XXX" \
-                -var "private_route_table_ids=XXX"
+                -var "private_route_table_ids=XXX" \
+                -var "s3_secrets_bucket=XXX" \
+                -var "jwt_encryption_key_path=XXX" \
+                -var "jwt_signing_key_path=XXX"
+                -var "survey_launcher_tag=latest"
 ```

--- a/ecs.tf
+++ b/ecs.tf
@@ -2,14 +2,26 @@ resource "aws_ecs_cluster" "eq" {
   name = "${var.env}-eq"
 }
 
+data "template_file" "ecs_user_data" {
+  template = "${file("${path.module}/templates/ecs_launch_config.tpl")}"
+
+  vars {
+    ECS_CLUSTER = "${aws_ecs_cluster.eq.name}"
+  }
+}
+
 resource "aws_launch_configuration" "ecs" {
-  name                   = "${var.env}-eq-ecs"
-  image_id               = "ami-175f1964" // Amazon ECS-Optimized AMI
+  name_prefix            = "${var.env}-eq-ecs-"
+  image_id               = "ami-175f1964" // Amazon ECS-Optimized AMI (see: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
   instance_type          = "${var.ecs_instance_type}"
   key_name               = "${var.ecs_aws_key_pair}"
   iam_instance_profile   = "${aws_iam_instance_profile.eq_ecs.id}"
   security_groups        = ["${aws_security_group.eq_ecs.id}"]
-  user_data              = "#!/bin/bash\necho ECS_CLUSTER=${aws_ecs_cluster.eq.name} > /etc/ecs/ecs.config"
+  user_data              = "${data.template_file.ecs_user_data.rendered}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_group" "eq_ecs" {

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -79,3 +79,21 @@ variable "dns_zone_name" {
 variable "certificate_arn" {
   description = "ARN of the IAM loaded TLS certificate for public ELB"
 }
+
+# survey-launcher
+variable "survey_launcher_tag" {
+  description = "The tag for the Survey Launcher image to run"
+  default = "latest"
+}
+
+variable "s3_secrets_bucket" {
+  description = "The S3 bucket that contains the secrets"
+}
+
+variable "jwt_encryption_key_path" {
+  description = "Path to the JWT Encryption Key (PEM format)"
+}
+
+variable "jwt_signing_key_path" {
+  description = "Path to the JWT Signing Key (PEM format)"
+}

--- a/iam.tf
+++ b/iam.tf
@@ -50,7 +50,16 @@ data "aws_iam_policy_document" "eq_ecs" {
       ]
     }
 
-
+  "statement" = {
+      "effect" = "Allow",
+      "actions" = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "resources" = [
+        "*"
+      ]
+    }
 }
 
 resource "aws_iam_role_policy" "eq_ecs" {

--- a/task-definitions/survey-launcher.json
+++ b/task-definitions/survey-launcher.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "survey-launcher",
-    "image": "onsdigital/go-launch-a-survey",
+    "image": "onsdigital/go-launch-a-survey:${CONTAINER_TAG}",
     "memoryReservation": 128,
     "essential": true,
     "portMappings": [
@@ -14,7 +14,26 @@
       {
         "name": "SURVEY_RUNNER_URL",
         "value": "${SURVEY_RUNNER_URL}"
+      },
+      {
+        "name": "JWT_ENCRYPTION_KEY_PATH",
+        "value": "${JWT_ENCRYPTION_KEY_PATH}"
+      },
+      {
+        "name": "JWT_SIGNING_KEY_PATH",
+        "value": "${JWT_SIGNING_KEY_PATH}"
+      },
+      {
+        "name": "SECRETS_S3_BUCKET",
+        "value": "${SECRETS_S3_BUCKET}"
       }
-    ]
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "eu-west-1",
+        "awslogs-group": "${LOG_GROUP}"
+      }
+    }
   }
 ]

--- a/templates/ecs_launch_config.tpl
+++ b/templates/ecs_launch_config.tpl
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo ECS_CLUSTER=${ECS_CLUSTER} > /etc/ecs/ecs.config
+echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
+echo ECS_AVAILABLE_LOGGING_DRIVERS=[\"json-file\",\"awslogs\"] >> /etc/ecs/ecs.config


### PR DESCRIPTION
Supporting terraform change for https://github.com/ONSdigital/go-launch-a-survey/pull/10

To run this module in terraform add the following module to the survey-runner.tf

```
module "survey-runner-ecs" {
  source = "github.com/ONSdigital/eq-terraform-ecs?ref=secrets-from-s3"
  env = "${var.env}"
  aws_access_key = "${var.aws_access_key}"
  aws_secret_key = "${var.aws_secret_key}"
  dns_zone_id = "${var.dns_zone_id}"
  dns_zone_name = "${var.dns_zone_name}"
  certificate_arn = "${var.certificate_arn}"
  vpc_id = "${module.survey-runner-vpc.vpc_id}"
  public_subnet_ids = "${module.survey-runner-routing.public_subnet_ids}"
  ecs_application_cidrs = "${var.ecs_application_cidrs}"
  private_route_table_ids = "${module.survey-runner-routing.private_route_table_ids}"
  jwt_encryption_key_path = "/secrets/sdc-user-authentication-encryption-sr-public-key.pem"
  jwt_signing_key_path = "/secrets/sdc-user-authentication-signing-rrm-private-key.pem"
  s3_secrets_bucket = "YOURNAME-secrets"
  survey_launcher_tag = "added-docker-entrypoint"
}
```

You will need to manually create a S3 bucket and add the file from jwt-test-keys in the go-launch-a-survey repo.

When the application is launched if should successfully redirect to survey-runner and the cloud watch logs should show that it copied the secrets from S3