### PR TITLE
Remove the need to pass in DNS parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ module "survey-runner-ecs" {
   env = "${var.env}"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"
-  dns_zone_id = "${var.dns_zone_id}"
-  dns_zone_name = "${var.dns_zone_name}"
   certificate_arn = "${var.certificate_arn}"
   vpc_id = "${module.survey-runner-vpc.vpc_id}"
   public_subnet_ids = "${module.survey-runner-routing.public_subnet_ids}"
@@ -26,8 +24,6 @@ To run this module on its own run the following code. (Replacing 'XXX' with you 
 terraform apply -var "env=XXX" \
                 -var "aws_access_key=XXX" \
                 -var "aws_secret_key=XXX" \
-                -var "dns_zone_id=XXX" \
-                -var "dns_zone_name=XXX" \
                 -var "certificate_arn=XXX" \
                 -var "vpc_id=XXX" \
                 -var "public_subnet_ids=XXX" \

--- a/aws.tf
+++ b/aws.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = "< 0.10.0" # Depends on https://github.com/terraform-providers/terraform-provider-aws/issues/1376
+}
+
 provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -60,17 +60,6 @@ variable "private_route_table_ids" {
   description = "Route tables with route to NAT gateway"
 }
 
-# DNS
-variable "dns_zone_id" {
-  description = "Amazon Route53 DNS zone identifier"
-  default     = "Z2XIERRF1SJEYP"
-}
-
-variable "dns_zone_name" {
-  description = "Amazon Route53 DNS zone name"
-  default     = "eq.ons.digital."
-}
-
 variable "certificate_arn" {
   description = "ARN of the IAM loaded TLS certificate for public ELB"
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -2,7 +2,4 @@ aws_access_key="XXXXXXXXXXXX"
 aws_secret_key = "XXXXXXXXXXXX"
 ecs_application_cidrs=["10.30.20.32/28", "10.30.20.48/28", "10.30.20.64/28"]
 
-dns_zone_id="XXXX"
-dns_zone_name="dev.eq.ons.digital"
-
 certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"


### PR DESCRIPTION
There is no need to pass the DNS parameter any more as they are not used.

Run the module using the example in the README