### PR TITLE
Auto deploy updated tags

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -63,3 +63,8 @@ variable "private_route_table_ids" {
 variable "certificate_arn" {
   description = "ARN of the IAM loaded TLS certificate for public ELB"
 }
+
+variable "auto_deploy_updated_tags" {
+  description = "Automatically deploy images when tags updated"
+  default     = false
+}

--- a/task-definitions/watchtower.json
+++ b/task-definitions/watchtower.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "watchtower",
+    "image": "centurylink/watchtower",
+    "memoryReservation": 128,
+    "essential": true,
+    "mountPoints": [
+      {
+        "sourceVolume": "docker",
+        "containerPath": "/var/run/docker.sock"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "eu-west-1",
+        "awslogs-group": "${LOG_GROUP}"
+      }
+    }
+  }
+]

--- a/watchtower.tf
+++ b/watchtower.tf
@@ -1,0 +1,32 @@
+data "template_file" "watchtower" {
+  template = "${file("${path.module}/task-definitions/watchtower.json")}"
+
+  vars {
+    LOG_GROUP = "${aws_cloudwatch_log_group.watchtower.name}"
+  }
+}
+
+resource "aws_ecs_task_definition" "watchtower" {
+  family                = "${var.env}-watchtower"
+  container_definitions = "${data.template_file.watchtower.rendered}"
+
+  volume {
+    name      = "docker"
+    host_path = "/var/run/docker.sock"
+  }
+}
+
+resource "aws_ecs_service" "watchtower" {
+  name            = "${var.env}-watchtower"
+  cluster         = "${aws_ecs_cluster.eq.id}"
+  task_definition = "${aws_ecs_task_definition.watchtower.family}"
+  desired_count   = "${(var.auto_deploy_updated_tags == false ? 0 : var.ecs_cluster_min_size)}"
+}
+
+resource "aws_cloudwatch_log_group" "watchtower" {
+  name = "${var.env}-watchtower"
+
+  tags {
+    Environment = "${var.env}"
+  }
+}


### PR DESCRIPTION
Enabling `auto_deploy_updated_tags` deploys `centurylink/watchtower` which is a container that looks for changes of tags and updates the container to the latest version. 
This check runs every 5 minutes.
During the update there will be a small period of downtime so this is only really idea for Dev and possibly pre-prod until we make our tags immutable.
