### PR TITLE
Restrict ECS to access only allow access from Public subnets

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,7 +1,7 @@
 resource "aws_alb" "eq" {
   name            = "${var.env}-eq-alb"
   internal        = false
-  security_groups = ["${aws_security_group.eq_alb.id}"]
+  security_groups = ["${join("", aws_security_group.eq_alb_waf_access.*.id)}", "${join("", aws_security_group.eq_alb_ons_access.*.id)}"]
   subnets         = ["${var.public_subnet_ids}"]
 
   tags {

--- a/aws.tf
+++ b/aws.tf
@@ -9,3 +9,8 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
+
+data "aws_subnet" "public_subnet" {
+  count = 3
+  id    = "${var.public_subnet_ids[count.index]}"
+}

--- a/ecs.tf
+++ b/ecs.tf
@@ -16,7 +16,7 @@ resource "aws_launch_configuration" "ecs" {
   instance_type        = "${var.ecs_instance_type}"
   key_name             = "${var.ecs_aws_key_pair}"
   iam_instance_profile = "${aws_iam_instance_profile.eq_ecs.id}"
-  security_groups      = ["${aws_security_group.eq_ecs.id}"]
+  security_groups      = ["${aws_security_group.eq_ecs_alb_access.id}"]
   user_data            = "${data.template_file.ecs_user_data.rendered}"
 
   lifecycle {

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -46,8 +46,9 @@ variable "public_subnet_ids" {
 }
 
 variable "vpc_peer_cidr_block" {
+  type        = "list"
   description = "The CIDR block of the peered VPC, optional"
-  default     = "0.0.0.0/0"
+  default = []
 }
 
 variable "ecs_application_cidrs" {
@@ -58,6 +59,12 @@ variable "ecs_application_cidrs" {
 variable "private_route_table_ids" {
   type        = "list"
   description = "Route tables with route to NAT gateway"
+}
+
+variable "ons_access_ips" {
+  type        = "list"
+  description = "List of IP's or IP ranges to allow access from ONS"
+  default = []
 }
 
 variable "certificate_arn" {

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,13 +1,14 @@
-resource "aws_security_group" "eq_alb" {
-  name        = "${var.env}-eq-alb"
-  description = "Allow access from the internet or WAF"
+resource "aws_security_group" "eq_alb_waf_access" {
+  name        = "${var.env}-eq-alb-access-from-waf"
+  description = "Allow access to the ALB from the WAF"
   vpc_id      = "${var.vpc_id}"
+  count       = "${length(var.vpc_peer_cidr_block) > 0 ? 1 : 0}"
 
   ingress {
     from_port   = "443"
     to_port     = "443"
     protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_peer_cidr_block}"]
+    cidr_blocks = "${var.vpc_peer_cidr_block}"
   }
 
   egress {
@@ -18,21 +19,47 @@ resource "aws_security_group" "eq_alb" {
   }
 
   tags {
-    Name        = "${var.env}-eq-alb-access"
+    Name        = "${var.env}-eq-ecs"
     Environment = "${var.env}"
   }
 }
 
-resource "aws_security_group" "eq_ecs" {
-  name        = "${var.env}-eq-ecs"
-  description = "Allow access from the internet or WAF"
+resource "aws_security_group" "eq_alb_ons_access" {
+  name        = "${var.env}-eq-alb-access-from-ons"
+  description = "Allow access to ALB from the ONS"
+  vpc_id      = "${var.vpc_id}"
+  count       = "${length(var.ons_access_ips) > 0 ? 1 : 0}"
+
+  ingress {
+    from_port   = "443"
+    to_port     = "443"
+    protocol    = "tcp"
+    cidr_blocks = "${var.ons_access_ips}"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name        = "${var.env}-eq-ecs"
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_security_group" "eq_ecs_alb_access" {
+  name        = "${var.env}-eq-ecs-access-from-alb"
+  description = "Allow access from ALB in public subnets"
   vpc_id      = "${var.vpc_id}"
 
   ingress {
     from_port   = "0"
     to_port     = "65535"
     protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_peer_cidr_block}"]
+    cidr_blocks = ["${data.aws_subnet.public_subnet.*.cidr_block}"]
   }
 
   egress {
@@ -43,7 +70,7 @@ resource "aws_security_group" "eq_ecs" {
   }
 
   tags {
-    Name        = "${var.env}-eq-ecs-access"
+    Name        = "${var.env}-eq-ecs"
     Environment = "${var.env}"
   }
 }


### PR DESCRIPTION
The ECS cluster should now only be accessible via the public subnets (e.g. the ALB) and not directly.
