### PR TITLE
Make ECS instance storage size configurable use latest AMI

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -10,9 +10,23 @@ data "template_file" "ecs_user_data" {
   }
 }
 
+data "aws_ami" "amazon_ecs_ami" {
+  most_recent = true
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  name_regex = ".+-amazon-ecs-optimized$"
+
+  most_recent = true
+}
+
+
 resource "aws_launch_configuration" "ecs" {
   name_prefix          = "${var.env}-eq-ecs-"
-  image_id             = "ami-175f1964"                                 // Amazon ECS-Optimized AMI (see: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
+  image_id             = "${data.aws_ami.amazon_ecs_ami.id}"
   instance_type        = "${var.ecs_instance_type}"
   key_name             = "${var.ecs_aws_key_pair}"
   iam_instance_profile = "${aws_iam_instance_profile.eq_ecs.id}"

--- a/ecs.tf
+++ b/ecs.tf
@@ -33,6 +33,11 @@ resource "aws_launch_configuration" "ecs" {
   security_groups      = ["${aws_security_group.eq_ecs_alb_access.id}"]
   user_data            = "${data.template_file.ecs_user_data.rendered}"
 
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "${var.ecs_instance_storage_size}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -21,6 +21,11 @@ variable "ecs_instance_type" {
   default     = "t2.medium"
 }
 
+variable "ecs_instance_storage_size" {
+  description = "The root block storage size (in GB) of the EC2 instance"
+  default     = 100
+}
+
 variable "ecs_aws_key_pair" {
   description = "Amazon Web Service Key Pair for use by ecs - in production this value should be empty"
   default     = ""


### PR DESCRIPTION
The PR allows us to increase the root storage size of the ECS instances.

I have also changed the way we lookup the ECS instance AMI id so that we always launch the latest version of the AMI.

To test this change your `eq-ecs` module to point at this branch in `eq-terraform` by appending `?ref=ecs-instance-updates` to the end of the source