### PR TITLE
Always allow the ECS cluster to call the ALB via the NAT gateways

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,7 +1,7 @@
 resource "aws_alb" "eq" {
   name            = "${var.env}-eq-alb"
   internal        = false
-  security_groups = ["${join("", aws_security_group.eq_alb_waf_access.*.id)}", "${join("", aws_security_group.eq_alb_ons_access.*.id)}"]
+  security_groups = ["${aws_security_group.eq_alb_ecs_access.id}", "${join("", aws_security_group.eq_alb_waf_access.*.id)}", "${join("", aws_security_group.eq_alb_ons_access.*.id)}"]
   subnets         = ["${var.public_subnet_ids}"]
 
   tags {

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -66,6 +66,11 @@ variable "private_route_table_ids" {
   description = "Route tables with route to NAT gateway"
 }
 
+variable "eq_gateway_ips" {
+  type        = "list"
+  description = "A list of External IP addresses for the EQ services"
+}
+
 variable "ons_access_ips" {
   type        = "list"
   description = "List of IP's or IP ranges to allow access from ONS"

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -50,6 +50,24 @@ resource "aws_security_group" "eq_alb_ons_access" {
   }
 }
 
+resource "aws_security_group" "eq_alb_ecs_access" {
+  name        = "${var.env}-eq-alb-access-from-ecs"
+  description = "Allow access to ALB from the ECS cluster"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    from_port   = "443"
+    to_port     = "443"
+    protocol    = "tcp"
+    cidr_blocks = ["${formatlist("%s/32", var.eq_gateway_ips)}"]
+  }
+
+  tags {
+    Name        = "${var.env}-eq-ecs"
+    Environment = "${var.env}"
+  }
+}
+
 resource "aws_security_group" "eq_ecs_alb_access" {
   name        = "${var.env}-eq-ecs-access-from-alb"
   description = "Allow access from ALB in public subnets"


### PR DESCRIPTION
This change is required so that publisher is able to call the author-api.

This can be tested by running https://github.com/ONSdigital/eq-terraform/pull/105