### PR TITLE
Fix False default for Auto Deploy

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -83,5 +83,5 @@ variable "certificate_arn" {
 
 variable "auto_deploy_updated_tags" {
   description = "Automatically deploy images when tags updated"
-  default     = false
+  default     = "false"
 }


### PR DESCRIPTION
To deploy run with default value for `auto_deploy_updated_tags` and ensure that the watchtower service is not deployed