### PR TITLE
Add S3 backend config

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_version = ">= 0.10.0, < 0.11.0"
+
+  backend "s3" {
+    region = "eu-west-1"
+  }
+}
+
 provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"


### PR DESCRIPTION
Adds the S3 backend config to allow terraform to store its state in S3 without Jenkins injecting a file