### PR TITLE
Respawn ECS agent if it dies

### DIFF
--- a/templates/ecs_launch_config.tpl
+++ b/templates/ecs_launch_config.tpl
@@ -2,3 +2,6 @@
 echo ECS_CLUSTER=${ECS_CLUSTER} > /etc/ecs/ecs.config
 echo ECS_ENABLE_TASK_IAM_ROLE=true >> /etc/ecs/ecs.config
 echo ECS_AVAILABLE_LOGGING_DRIVERS=[\"json-file\",\"awslogs\"] >> /etc/ecs/ecs.config
+
+echo respawn >> /etc/init/ecs.conf
+echo respawn limit 10 5 >> /etc/init/ecs.conf


### PR DESCRIPTION
if the ECS agent fails with a Critical error then it does not restart.

This change means that the service will restart on a Critical error