### PR TITLE
Add new variable to customise the cluster name

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,17 +1,17 @@
-resource "aws_alb" "eq" {
-  name            = "${var.env}-eq-alb"
+resource "aws_alb" "default" {
+  name            = "${var.env}-${var.ecs_cluster_name}-alb"
   internal        = false
-  security_groups = ["${aws_security_group.eq_alb_ecs_access.id}", "${join("", aws_security_group.eq_alb_waf_access.*.id)}", "${join("", aws_security_group.eq_alb_ons_access.*.id)}"]
+  security_groups = ["${aws_security_group.alb_ecs_access.id}", "${join("", aws_security_group.alb_waf_access.*.id)}", "${join("", aws_security_group.alb_ons_access.*.id)}"]
   subnets         = ["${var.public_subnet_ids}"]
 
   tags {
-    Name        = "survey-runner-alb"
+    Name        = "${var.ecs_cluster_name}-alb"
     Environment = "${var.env}"
   }
 }
 
-resource "aws_alb_listener" "eq" {
-  load_balancer_arn = "${aws_alb.eq.arn}"
+resource "aws_alb_listener" "default" {
+  load_balancer_arn = "${aws_alb.default.arn}"
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
@@ -24,7 +24,7 @@ resource "aws_alb_listener" "eq" {
 }
 
 resource "aws_alb_target_group" "default_target_group" {
-  name     = "${var.env}-default-target-group"
+  name     = "${var.env}-${var.ecs_cluster_name}-dtg"
   port     = 80
   protocol = "HTTP"
   vpc_id   = "${var.vpc_id}"

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudwatch_metric_alarm" "eq_ecs_high_cpu" {
-  alarm_name          = "${var.env}-eq-ecs-high-cpu"
+resource "aws_cloudwatch_metric_alarm" "ecs_high_cpu" {
+  alarm_name          = "${var.env}-${var.ecs_cluster_name}-ecs-high-cpu"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
@@ -9,15 +9,15 @@ resource "aws_cloudwatch_metric_alarm" "eq_ecs_high_cpu" {
   threshold           = "40"
 
   dimensions {
-    AutoScalingGroupName = "${aws_autoscaling_group.eq_ecs.name}"
+    AutoScalingGroupName = "${aws_autoscaling_group.ecs.name}"
   }
 
   alarm_description = "This metric monitors ECS Instance cpu utilization"
-  alarm_actions     = ["${aws_autoscaling_policy.eq_ecs_scaling.arn}"]
+  alarm_actions     = ["${aws_autoscaling_policy.ecs_scaling.arn}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "eq_ecs_low_cpu" {
-  alarm_name          = "${var.env}-eq-ecs-low-cpu"
+resource "aws_cloudwatch_metric_alarm" "ecs_low_cpu" {
+  alarm_name          = "${var.env}-${var.ecs_cluster_name}-ecs-low-cpu"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "5"
   metric_name         = "CPUUtilization"
@@ -27,9 +27,9 @@ resource "aws_cloudwatch_metric_alarm" "eq_ecs_low_cpu" {
   threshold           = "20"
 
   dimensions {
-    AutoScalingGroupName = "${aws_autoscaling_group.eq_ecs.name}"
+    AutoScalingGroupName = "${aws_autoscaling_group.ecs.name}"
   }
 
   alarm_description = "This metric monitors ECS Instance cpu utilization"
-  alarm_actions     = ["${aws_autoscaling_policy.eq_ecs_scaling.arn}"]
+  alarm_actions     = ["${aws_autoscaling_policy.ecs_scaling.arn}"]
 }

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -31,6 +31,10 @@ variable "ecs_aws_key_pair" {
   default     = ""
 }
 
+variable "ecs_cluster_name" {
+  description = "A unique name for the ecs cluster"
+}
+
 variable "ecs_cluster_min_size" {
   description = "ECS Cluster Minimum number of instances"
   default     = "3"
@@ -66,9 +70,9 @@ variable "private_route_table_ids" {
   description = "Route tables with route to NAT gateway"
 }
 
-variable "eq_gateway_ips" {
+variable "gateway_ips" {
   type        = "list"
-  description = "A list of External IP addresses for the EQ services"
+  description = "A list of External IP addresses for the service"
 }
 
 variable "ons_access_ips" {

--- a/iam.tf
+++ b/iam.tf
@@ -1,10 +1,10 @@
-resource "aws_iam_instance_profile" "eq_ecs" {
-  name = "${var.env}_iam_instance_profile_for_eq_ecs"
-  role = "${aws_iam_role.eq_ecs.name}"
+resource "aws_iam_instance_profile" "ecs" {
+  name = "${var.env}_iam_instance_profile_for_${var.ecs_cluster_name}_ecs"
+  role = "${aws_iam_role.ecs.name}"
 }
 
-resource "aws_iam_role" "eq_ecs" {
-  name = "${var.env}_iam_instance_profile_for_eq_ecs"
+resource "aws_iam_role" "ecs" {
+  name = "${var.env}_iam_instance_profile_for_${var.ecs_cluster_name}_ecs"
 
   assume_role_policy = <<EOF
 {
@@ -23,7 +23,7 @@ resource "aws_iam_role" "eq_ecs" {
 EOF
 }
 
-data "aws_iam_policy_document" "eq_ecs" {
+data "aws_iam_policy_document" "ecs" {
   "statement" = {
     "effect" = "Allow"
 
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "eq_ecs" {
     ]
 
     "resources" = [
-      "arn:aws:ecs:eu-west-1:${data.aws_caller_identity.current.account_id}:cluster/${aws_ecs_cluster.eq.name}",
+      "arn:aws:ecs:eu-west-1:${data.aws_caller_identity.current.account_id}:cluster/${aws_ecs_cluster.default.name}",
     ]
   }
 
@@ -83,8 +83,8 @@ data "aws_iam_policy_document" "eq_ecs" {
   }
 }
 
-resource "aws_iam_role_policy" "eq_ecs" {
-  name   = "${var.env}_iam_instance_profile_for_eq_ecs"
-  role   = "${aws_iam_role.eq_ecs.id}"
-  policy = "${data.aws_iam_policy_document.eq_ecs.json}"
+resource "aws_iam_role_policy" "ecs" {
+  name   = "${var.env}_iam_instance_profile_for_${var.ecs_cluster_name}_ecs"
+  role   = "${aws_iam_role.ecs.id}"
+  policy = "${data.aws_iam_policy_document.ecs.json}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,15 @@
 output "ecs_cluster_name" {
-  value = "${aws_ecs_cluster.eq.name}"
+  value = "${aws_ecs_cluster.default.name}"
 }
 
 output "aws_alb_dns_name" {
-  value = "${aws_alb.eq.dns_name}"
+  value = "${aws_alb.default.dns_name}"
 }
 
 output "aws_alb_listener_arn" {
-  value = "${aws_alb_listener.eq.arn}"
+  value = "${aws_alb_listener.default.arn}"
 }
 
 output "aws_alb_arn" {
-  value = "${aws_alb.eq.arn}"
+  value = "${aws_alb.default.arn}"
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,5 +1,5 @@
-resource "aws_security_group" "eq_alb_waf_access" {
-  name        = "${var.env}-eq-alb-access-from-waf"
+resource "aws_security_group" "alb_waf_access" {
+  name        = "${var.env}-${var.ecs_cluster_name}-alb-access-from-waf"
   description = "Allow access to the ALB from the WAF"
   vpc_id      = "${var.vpc_id}"
   count       = "${length(var.vpc_peer_cidr_block) > 0 ? 1 : 0}"
@@ -19,13 +19,13 @@ resource "aws_security_group" "eq_alb_waf_access" {
   }
 
   tags {
-    Name        = "${var.env}-eq-ecs"
+    Name        = "${var.env}-${var.ecs_cluster_name}-ecs"
     Environment = "${var.env}"
   }
 }
 
-resource "aws_security_group" "eq_alb_ons_access" {
-  name        = "${var.env}-eq-alb-access-from-ons"
+resource "aws_security_group" "alb_ons_access" {
+  name        = "${var.env}-${var.ecs_cluster_name}-alb-access-from-ons"
   description = "Allow access to ALB from the ONS"
   vpc_id      = "${var.vpc_id}"
   count       = "${length(var.ons_access_ips) > 0 ? 1 : 0}"
@@ -45,13 +45,13 @@ resource "aws_security_group" "eq_alb_ons_access" {
   }
 
   tags {
-    Name        = "${var.env}-eq-ecs"
+    Name        = "${var.env}-${var.ecs_cluster_name}-ecs"
     Environment = "${var.env}"
   }
 }
 
-resource "aws_security_group" "eq_alb_ecs_access" {
-  name        = "${var.env}-eq-alb-access-from-ecs"
+resource "aws_security_group" "alb_ecs_access" {
+  name        = "${var.env}-${var.ecs_cluster_name}-alb-access-from-ecs"
   description = "Allow access to ALB from the ECS cluster"
   vpc_id      = "${var.vpc_id}"
 
@@ -59,17 +59,17 @@ resource "aws_security_group" "eq_alb_ecs_access" {
     from_port   = "443"
     to_port     = "443"
     protocol    = "tcp"
-    cidr_blocks = ["${formatlist("%s/32", var.eq_gateway_ips)}"]
+    cidr_blocks = ["${formatlist("%s/32", var.gateway_ips)}"]
   }
 
   tags {
-    Name        = "${var.env}-eq-ecs"
+    Name        = "${var.env}-${var.ecs_cluster_name}-ecs"
     Environment = "${var.env}"
   }
 }
 
-resource "aws_security_group" "eq_ecs_alb_access" {
-  name        = "${var.env}-eq-ecs-access-from-alb"
+resource "aws_security_group" "ecs_alb_access" {
+  name        = "${var.env}-${var.ecs_cluster_name}-ecs-access-from-alb"
   description = "Allow access from ALB in public subnets"
   vpc_id      = "${var.vpc_id}"
 
@@ -88,7 +88,7 @@ resource "aws_security_group" "eq_ecs_alb_access" {
   }
 
   tags {
-    Name        = "${var.env}-eq-ecs"
+    Name        = "${var.env}-${var.ecs_cluster_name}-ecs"
     Environment = "${var.env}"
   }
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -6,7 +6,7 @@ resource "aws_subnet" "ecs_application" {
   availability_zone = "${var.availability_zones[count.index]}"
 
   tags {
-    Name        = "${var.env}-ecs-application-subnet-${count.index+1}"
+    Name        = "${var.env}-${var.ecs_cluster_name}-ecs-application-subnet-${count.index+1}"
     Environment = "${var.env}"
     Type        = "Application"
   }

--- a/watchtower.tf
+++ b/watchtower.tf
@@ -9,7 +9,7 @@ data "template_file" "watchtower" {
 
 resource "aws_ecs_task_definition" "watchtower" {
   count                 = "${(var.auto_deploy_updated_tags == false ? 0 : 1)}"
-  family                = "${var.env}-watchtower"
+  family                = "${var.env}-${var.ecs_cluster_name}-watchtower"
   container_definitions = "${data.template_file.watchtower.rendered}"
 
   volume {
@@ -19,15 +19,15 @@ resource "aws_ecs_task_definition" "watchtower" {
 }
 
 resource "aws_ecs_service" "watchtower" {
-  name            = "${var.env}-watchtower"
+  name            = "${var.env}-${var.ecs_cluster_name}-watchtower"
   count           = "${(var.auto_deploy_updated_tags == false ? 0 : 1)}"
-  cluster         = "${aws_ecs_cluster.eq.id}"
+  cluster         = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.watchtower.family}"
   desired_count   = "${var.ecs_cluster_min_size}"
 }
 
 resource "aws_cloudwatch_log_group" "watchtower" {
-  name  = "${var.env}-watchtower"
+  name  = "${var.env}-${var.ecs_cluster_name}-watchtower"
   count = "${(var.auto_deploy_updated_tags == false ? 0 : 1)}"
 
   tags {


### PR DESCRIPTION
## Description

As part of the work to set up a production environment for Author we need to spin up an ECS cluster completely separate from survey runner so as to avoid any cross-contamination of data from the author environment leaking into the same environment for survey runner. i.e. we wouldn't want data from Author prod to be previewed in survey runner prod necessarily.

This change is required to allow author to customise the ECS cluster name.
A new variable has been added which is referenced within the `author.tf` file being introduced in the [corresponding eq-terraform PR](https://github.com/ONSdigital/eq-terraform/pull/144).