### PR TITLE
Output variables to support using Fargate

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,11 @@ output "aws_alb_listener_arn" {
 output "aws_alb_arn" {
   value = "${aws_alb.eq.arn}"
 }
+
+output "ecs_subnet_ids" {
+  value = "${aws_subnet.ecs_application.*.id}"
+}
+
+output "ecs_alb_security_group" {
+  value = "${aws_security_group.eq_ecs_alb_access.id}"
+}


### PR DESCRIPTION
These values are required by `eq-ecs-deploy` to deploy containers on Fargate