### PR TITLE
Support internal alb

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,16 +1,19 @@
+// Externally accessible ALB 
 resource "aws_alb" "default" {
-  name            = "${var.env}-${var.ecs_cluster_name}-alb"
+  count           = "${var.create_external_elb ? 1 : 0}"
+  name            = "${var.env}-${var.ecs_cluster_name}-external-alb"
   internal        = false
-  security_groups = ["${aws_security_group.alb_ecs_access.id}", "${join("", aws_security_group.alb_waf_access.*.id)}", "${join("", aws_security_group.alb_ons_access.*.id)}"]
+  security_groups = ["${aws_security_group.alb_ecs_access.id}", "${join("", aws_security_group.alb_ons_access.*.id)}"]
   subnets         = ["${var.public_subnet_ids}"]
 
   tags {
-    Name        = "${var.ecs_cluster_name}-alb"
+    Name        = "${var.ecs_cluster_name}-external-alb"
     Environment = "${var.env}"
   }
 }
 
 resource "aws_alb_listener" "default" {
+  count             = "${var.create_external_elb ? 1 : 0}"
   load_balancer_arn = "${aws_alb.default.arn}"
   port              = "443"
   protocol          = "HTTPS"
@@ -25,6 +28,39 @@ resource "aws_alb_listener" "default" {
 
 resource "aws_alb_target_group" "default_target_group" {
   name     = "${var.env}-${var.ecs_cluster_name}-dtg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+}
+
+// Internal ALB for WAF
+resource "aws_alb" "internal" {
+  count           = "${var.create_internal_elb ? 1 : 0}"
+  name            = "${var.env}-${var.ecs_cluster_name}-internal-alb"
+  internal        = true
+  security_groups = ["${join("", aws_security_group.alb_waf_access.*.id)}"]
+  subnets         = ["${aws_subnet.ecs_application.*.id}"]
+
+  tags {
+    Name        = "${var.ecs_cluster_name}-internal-alb"
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_alb_listener" "internal" {
+  count             = "${var.create_internal_elb ? 1 : 0}"
+  load_balancer_arn = "${aws_alb.internal.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.internal_default_target_group.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_target_group" "internal_default_target_group" {
+  name     = "${var.env}-${var.ecs_cluster_name}-internal-dtg"
   port     = 80
   protocol = "HTTP"
   vpc_id   = "${var.vpc_id}"

--- a/aws.tf
+++ b/aws.tf
@@ -6,10 +6,12 @@ terraform {
 
 provider "aws" {
   allowed_account_ids = ["${var.aws_account_id}"]
+
   assume_role {
-    role_arn  = "${var.aws_assume_role_arn}"
+    role_arn = "${var.aws_assume_role_arn}"
   }
-  region     = "eu-west-1"
+
+  region = "eu-west-1"
 }
 
 data "aws_caller_identity" "current" {}

--- a/ecs.tf
+++ b/ecs.tf
@@ -19,9 +19,7 @@ data "aws_ami" "amazon_ecs_ami" {
   }
 
   name_regex = ".+-amazon-ecs-optimized$"
-
 }
-
 
 resource "aws_launch_configuration" "ecs" {
   name_prefix          = "${var.env}-${var.ecs_cluster_name}-ecs-"

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -57,7 +57,7 @@ variable "public_subnet_ids" {
 variable "vpc_peer_cidr_block" {
   type        = "list"
   description = "The CIDR block of the peered VPC, optional"
-  default = []
+  default     = []
 }
 
 variable "ecs_application_cidrs" {
@@ -78,7 +78,7 @@ variable "gateway_ips" {
 variable "ons_access_ips" {
   type        = "list"
   description = "List of IP's or IP ranges to allow access from ONS"
-  default = []
+  default     = []
 }
 
 variable "certificate_arn" {
@@ -88,4 +88,14 @@ variable "certificate_arn" {
 variable "auto_deploy_updated_tags" {
   description = "Automatically deploy images when tags updated"
   default     = "false"
+}
+
+variable "create_external_elb" {
+  description = "Deploy an external load balancer"
+  default     = false
+}
+
+variable "create_internal_elb" {
+  description = "Deploy an internal load balancer"
+  default     = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,11 +6,11 @@ output "aws_alb_dns_name" {
   value = "${aws_alb.default.dns_name}"
 }
 
-output "aws_alb_listener_arn" {
+output "aws_external_alb_listener_arn" {
   value = "${aws_alb_listener.default.arn}"
 }
 
-output "aws_alb_arn" {
+output "aws_external_alb_arn" {
   value = "${aws_alb.default.arn}"
 }
 

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,12 +1,12 @@
 resource "aws_security_group" "alb_waf_access" {
+  count       = "${var.create_internal_elb ? 1 : 0}"
   name        = "${var.env}-${var.ecs_cluster_name}-alb-access-from-waf"
   description = "Allow access to the ALB from the WAF"
   vpc_id      = "${var.vpc_id}"
-  count       = "${length(var.vpc_peer_cidr_block) > 0 ? 1 : 0}"
 
   ingress {
-    from_port   = "443"
-    to_port     = "443"
+    from_port   = "80"
+    to_port     = "80"
     protocol    = "tcp"
     cidr_blocks = "${var.vpc_peer_cidr_block}"
   }
@@ -78,6 +78,13 @@ resource "aws_security_group" "ecs_alb_access" {
     to_port     = "65535"
     protocol    = "tcp"
     cidr_blocks = ["${data.aws_subnet.public_subnet.*.cidr_block}"]
+  }
+
+  ingress {
+    from_port   = "0"
+    to_port     = "65535"
+    protocol    = "tcp"
+    cidr_blocks = ["${aws_subnet.ecs_application.*.cidr_block}"]
   }
 
   egress {


### PR DESCRIPTION
Allow an internal ALB to be deployed alongside an optional external ALB.

This allows us to put runner behind an internal ALB in PreProd while maintaining the external ALB for apps not behind the WAF, (eg, launcher)

This also allows us to deploy just an internal ALB in Prod where there are no services that should be accessible not via WAF