### PR TITLE
Output variables required for Fargate

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,11 @@ output "aws_alb_listener_arn" {
 output "aws_alb_arn" {
   value = "${aws_alb.default.arn}"
 }
+
+output "ecs_subnet_ids" {
+  value = "${aws_subnet.ecs_application.*.id}"
+}
+
+output "ecs_alb_security_group" {
+  value = "${aws_security_group.ecs_alb_access.id}"
+}


### PR DESCRIPTION
Fargate allows us to run containers serverless.

https://aws.amazon.com/fargate/