### PR TITLE
Add manadatory `owners` property to ami definition.

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -12,6 +12,7 @@ data "template_file" "ecs_user_data" {
 
 data "aws_ami" "amazon_ecs_ami" {
   most_recent = true
+  owners = ["amazon"]
 
   filter {
     name   = "owner-alias"


### PR DESCRIPTION
There was a change in v2.0 of the AWS terraform provider that broke our concourse pipeline. The new version makes the `owners` setting mandatory. We were not setting it in our configuration.

This change updates the `owners` property to "amazon" as per https://www.terraform.io/docs/providers/aws/d/ami.html#owners.